### PR TITLE
re-ordered inherited contracts to avoid "Linearization of inheritance…

### DIFF
--- a/contracts/KIP/access/IKAccessControl.sol
+++ b/contracts/KIP/access/IKAccessControl.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (access/IAccessControl.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev External interface of AccessControl declared to support ERC165 detection.
+ */
+interface IKAccessControl {
+    /**
+     * @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`
+     *
+     * `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
+     * {RoleAdminChanged} not being emitted signaling this.
+     *
+     * _Available since v3.1._
+     */
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+
+    /**
+     * @dev Emitted when `account` is granted `role`.
+     *
+     * `sender` is the account that originated the contract call, an admin role
+     * bearer except when using {AccessControl-_setupRole}.
+     */
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Emitted when `account` is revoked `role`.
+     *
+     * `sender` is the account that originated the contract call:
+     *   - if using `revokeRole`, it is the admin role bearer
+     *   - if using `renounceRole`, it is the role bearer (i.e. `account`)
+     */
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) external view returns (bool);
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {AccessControl-_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) external view returns (bytes32);
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function grantRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function revokeRole(bytes32 role, address account) external;
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been granted `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     */
+    function renounceRole(bytes32 role, address account) external;
+}

--- a/contracts/KIP/access/KAccessControl.sol
+++ b/contracts/KIP/access/KAccessControl.sol
@@ -1,16 +1,248 @@
 // SPDX-License-Identifier: MIT
-// Klaytn Contract Library v1.0.1 (KIP/access/KAccessControl.sol)
-// Inherited from Openzepplin Accesscontrol
-// https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v4.5.0
-// Note - adding KIP13 interface for a backward compatible implementation
+// Klaytn Contract Library (KIP/access/KAccessControl.sol)
+// Based on OpenZeppelin Contracts (last updated v4.6.0) (access/AccessControl.sol)
 
 pragma solidity ^0.8.0;
 
-import "../../access/AccessControl.sol";
+import "./IKAccessControl.sol";
+import "../../utils/Context.sol";
+import "../../utils/Strings.sol";
 import "../utils/introspection/KIP13.sol";
 
-abstract contract KAccessControl is KIP13, AccessControl {
-    function supportsInterface(bytes4 interfaceId) public view virtual override(KIP13, AccessControl) returns (bool) {
-        return super.supportsInterface(interfaceId);
+/**
+ * @dev Contract module that allows children to implement role-based access
+ * control mechanisms. This is a lightweight version that doesn't allow enumerating role
+ * members except through off-chain means by accessing the contract event logs. Some
+ * applications may benefit from on-chain enumerability, for those cases see
+ * {AccessControlEnumerable}.
+ *
+ * Roles are referred to by their `bytes32` identifier. These should be exposed
+ * in the external API and be unique. The best way to achieve this is by
+ * using `public constant` hash digests:
+ *
+ * ```
+ * bytes32 public constant MY_ROLE = keccak256("MY_ROLE");
+ * ```
+ *
+ * Roles can be used to represent a set of permissions. To restrict access to a
+ * function call, use {hasRole}:
+ *
+ * ```
+ * function foo() public {
+ *     require(hasRole(MY_ROLE, msg.sender));
+ *     ...
+ * }
+ * ```
+ *
+ * Roles can be granted and revoked dynamically via the {grantRole} and
+ * {revokeRole} functions. Each role has an associated admin role, and only
+ * accounts that have a role's admin role can call {grantRole} and {revokeRole}.
+ *
+ * By default, the admin role for all roles is `DEFAULT_ADMIN_ROLE`, which means
+ * that only accounts with this role will be able to grant or revoke other
+ * roles. More complex role relationships can be created by using
+ * {_setRoleAdmin}.
+ *
+ * WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
+ * grant and revoke this role. Extra precautions should be taken to secure
+ * accounts that have been granted it.
+ */
+abstract contract KAccessControl is Context, IKAccessControl, KIP13 {
+    struct RoleData {
+        mapping(address => bool) members;
+        bytes32 adminRole;
+    }
+
+    mapping(bytes32 => RoleData) private _roles;
+
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /**
+     * @dev Modifier that checks that an account has a specific role. Reverts
+     * with a standardized message including the required role.
+     *
+     * The format of the revert reason is given by the following regular expression:
+     *
+     *  /^AccessControl: account (0x[0-9a-f]{40}) is missing role (0x[0-9a-f]{64})$/
+     *
+     * _Available since v4.1._
+     */
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role);
+        _;
+    }
+
+    /**
+     * @dev See {IKIP13-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IKAccessControl).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) public view virtual override returns (bool) {
+        return _roles[role].members[account];
+    }
+
+    /**
+     * @dev Revert with a standard message if `_msgSender()` is missing `role`.
+     * Overriding this function changes the behavior of the {onlyRole} modifier.
+     *
+     * Format of the revert message is described in {_checkRole}.
+     *
+     * _Available since v4.6._
+     */
+    function _checkRole(bytes32 role) internal view virtual {
+        _checkRole(role, _msgSender());
+    }
+
+    /**
+     * @dev Revert with a standard message if `account` is missing `role`.
+     *
+     * The format of the revert reason is given by the following regular expression:
+     *
+     *  /^AccessControl: account (0x[0-9a-f]{40}) is missing role (0x[0-9a-f]{64})$/
+     */
+    function _checkRole(bytes32 role, address account) internal view virtual {
+        if (!hasRole(role, account)) {
+            revert(
+                string(
+                    abi.encodePacked(
+                        "AccessControl: account ",
+                        Strings.toHexString(uint160(account), 20),
+                        " is missing role ",
+                        Strings.toHexString(uint256(role), 32)
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) public view virtual override returns (bytes32) {
+        return _roles[role].adminRole;
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     *
+     * May emit a {RoleGranted} event.
+     */
+    function grantRole(bytes32 role, address account) public virtual override onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     *
+     * May emit a {RoleRevoked} event.
+     */
+    function revokeRole(bytes32 role, address account) public virtual override onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been revoked `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     *
+     * May emit a {RoleRevoked} event.
+     */
+    function renounceRole(bytes32 role, address account) public virtual override {
+        require(account == _msgSender(), "AccessControl: can only renounce roles for self");
+
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event. Note that unlike {grantRole}, this function doesn't perform any
+     * checks on the calling account.
+     *
+     * May emit a {RoleGranted} event.
+     *
+     * [WARNING]
+     * ====
+     * This function should only be called from the constructor when setting
+     * up the initial roles for the system.
+     *
+     * Using this function in any other way is effectively circumventing the admin
+     * system imposed by {KAccessControl}.
+     * ====
+     *
+     * NOTE: This function is deprecated in favor of {_grantRole}.
+     */
+    function _setupRole(bytes32 role, address account) internal virtual {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Sets `adminRole` as ``role``'s admin role.
+     *
+     * Emits a {RoleAdminChanged} event.
+     */
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        bytes32 previousAdminRole = getRoleAdmin(role);
+        _roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * Internal function without access restriction.
+     *
+     * May emit a {RoleGranted} event.
+     */
+    function _grantRole(bytes32 role, address account) internal virtual {
+        if (!hasRole(role, account)) {
+            _roles[role].members[account] = true;
+            emit RoleGranted(role, account, _msgSender());
+        }
+    }
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * Internal function without access restriction.
+     *
+     * May emit a {RoleRevoked} event.
+     */
+    function _revokeRole(bytes32 role, address account) internal virtual {
+        if (hasRole(role, account)) {
+            _roles[role].members[account] = false;
+            emit RoleRevoked(role, account, _msgSender());
+        }
     }
 }

--- a/contracts/KIP/token/KIP17/KIP17.sol
+++ b/contracts/KIP/token/KIP17/KIP17.sol
@@ -18,7 +18,7 @@ import "../../../token/ERC721/IERC721Receiver.sol";
  * the Metadata extension, but not including the Enumerable extension, which is available separately as
  * {KIP17Enumerable}.
  */
-contract KIP17 is KIP13, Context, IKIP17, IKIP17Metadata {
+contract KIP17 is Context, KIP13, IKIP17, IKIP17Metadata {
     using Address for address;
     using Strings for uint256;
 

--- a/contracts/KIP/token/KIP17/extensions/draft-KIP17Votes.sol
+++ b/contracts/KIP/token/KIP17/extensions/draft-KIP17Votes.sol
@@ -18,7 +18,7 @@ import "../../../../governance/utils/Votes.sol";
  *
  * _Available since v4.5._
  */
-abstract contract KIP17Votes is Votes, KIP17 {
+abstract contract KIP17Votes is KIP17, Votes {
     /**
      * @dev Adjusts votes when tokens are transferred.
      *

--- a/contracts/KIP/token/KIP37/KIP37.sol
+++ b/contracts/KIP/token/KIP37/KIP37.sol
@@ -19,7 +19,7 @@ import "../../utils/introspection/KIP13.sol";
  * Originally based on code by Enjin: https://github.com/enjin/erc-1155
  *
  */
-contract KIP37 is KIP13, IKIP37, IKIP37MetadataURI, Context {
+contract KIP37 is Context, KIP13, IKIP37, IKIP37MetadataURI {
     using Address for address;
 
     // Mapping from token ID to account balances

--- a/contracts/KIP/token/KIP7/KIP7.sol
+++ b/contracts/KIP/token/KIP7/KIP7.sol
@@ -35,7 +35,7 @@ import "./IKIP7Receiver.sol";
  *
  * See http://kips.klaytn.com/KIPs/kip-7-fungible_token
  */
-contract KIP7 is KIP13, Context, IKIP7, IKIP7Metadata {
+contract KIP7 is Context, KIP13, IKIP7, IKIP7Metadata {
     using Address for address;
 
     mapping(address => uint256) private _balances;

--- a/contracts/KIP/token/KIP7/presets/KIP7PresetMinterPauser.sol
+++ b/contracts/KIP/token/KIP7/presets/KIP7PresetMinterPauser.sol
@@ -26,7 +26,7 @@ import "../extensions/KIP7Pausable.sol";
  * roles, as well as the default admin role, which will let it grant both minter
  * and pauser roles to other accounts.
  */
-contract KIP7PresetMinterPauser is KIP13, Context, AccessControlEnumerable, KIP7Mintable, KIP7Burnable, KIP7Pausable {
+contract KIP7PresetMinterPauser is Context, KIP13,  AccessControlEnumerable, KIP7Mintable, KIP7Burnable, KIP7Pausable {
     /**
      * @dev Grants `DEFAULT_ADMIN_ROLE`, `MINTER_ROLE` and `PAUSER_ROLE` to the
      * account that deploys the contract.

--- a/contracts/KIP/token/KIP7/presets/KIP7PresetMinterPauser.sol
+++ b/contracts/KIP/token/KIP7/presets/KIP7PresetMinterPauser.sol
@@ -26,7 +26,7 @@ import "../extensions/KIP7Pausable.sol";
  * roles, as well as the default admin role, which will let it grant both minter
  * and pauser roles to other accounts.
  */
-contract KIP7PresetMinterPauser is Context, KIP13,  AccessControlEnumerable, KIP7Mintable, KIP7Burnable, KIP7Pausable {
+contract KIP7PresetMinterPauser is Context, KIP13, AccessControlEnumerable, KIP7Mintable, KIP7Burnable, KIP7Pausable {
     /**
      * @dev Grants `DEFAULT_ADMIN_ROLE`, `MINTER_ROLE` and `PAUSER_ROLE` to the
      * account that deploys the contract.


### PR DESCRIPTION
In this PR requesting a re-order in inherited contracts to avoid "Linearization of inheritance graph" issue in derived contracts.

## Proposed changes

Faced following issue while working on Klaytn Wizard [this](https://github.com/klaytn/klaytn-contracts-wizard/pull/3) PR.
>  | TypeError: Linearization of inheritance graph impossible
>  |   --> contracts/generated/17fe2b467dd941acbbfb5784cf5340592e8a79ca.sol:14:1:
>  |    |
>  | 14 | contract MyToken is KIP17, KIP17Enumerable, KIP17URIStorage, Pausable, Ownable, KIP17Burnable, EIP712, KIP17Votes {
>  |    | ^ (Relevant source part starts here and spans across multiple lines).

As per debugging the issue and reviewing the forked Openzeppelin relevant file [ERC721Votes.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/49c0e4370d0cc50ea6090709e3835a3091e33ee2/contracts/token/ERC721/extensions/ERC721Votes.sol#L19) I've found that we've reversed the order of inherited contracts i.e: `Votes, KIP17` in [draft-KIP17Votes.sol](https://github.com/klaytn/klaytn-contracts/blob/master/contracts/KIP/token/KIP17/extensions/draft-KIP17Votes.sol#L21)
Hence causing this issue. 
So fixing the order of inherited contract in `draft-KIP17Votes` to resolve the issue of `Linearization of inheritance graph impossible`
## Types of changes

- [x] Bugfix

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [x] Lint and unit tests pass locally with my changes

## Related issues

PR: https://github.com/klaytn/klaytn-contracts-wizard/pull/3
